### PR TITLE
feature: メトロノームを独立した画面として追加

### DIFF
--- a/lib/features/metronome/application/metronome_provider.dart
+++ b/lib/features/metronome/application/metronome_provider.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// メトロノームの状態
+class MetronomeState {
+  final int bpm;
+  final bool isEnabled;
+  final int beatsPerMeasure;
+  final bool accentEnabled;
+
+  const MetronomeState({
+    this.bpm = 120,
+    this.isEnabled = false,
+    this.beatsPerMeasure = 4,
+    this.accentEnabled = true,
+  });
+
+  MetronomeState copyWith({
+    int? bpm,
+    bool? isEnabled,
+    int? beatsPerMeasure,
+    bool? accentEnabled,
+  }) {
+    return MetronomeState(
+      bpm: bpm ?? this.bpm,
+      isEnabled: isEnabled ?? this.isEnabled,
+      beatsPerMeasure: beatsPerMeasure ?? this.beatsPerMeasure,
+      accentEnabled: accentEnabled ?? this.accentEnabled,
+    );
+  }
+}
+
+/// メトロノームの状態管理
+class MetronomeNotifier extends StateNotifier<MetronomeState> {
+  MetronomeNotifier() : super(const MetronomeState());
+
+  /// BPM範囲
+  static const int minBPM = 40;
+  static const int maxBPM = 240;
+
+  /// BPMを設定
+  void setBpm(int bpm) {
+    state = state.copyWith(bpm: bpm.clamp(minBPM, maxBPM));
+  }
+
+  /// メトロノームのON/OFF切り替え
+  void toggle() {
+    state = state.copyWith(isEnabled: !state.isEnabled);
+  }
+
+  /// メトロノームを停止
+  void stop() {
+    state = state.copyWith(isEnabled: false);
+  }
+
+  /// 拍子を設定
+  void setBeatsPerMeasure(int beats) {
+    state = state.copyWith(beatsPerMeasure: beats);
+  }
+
+  /// アクセントのON/OFF切り替え
+  void toggleAccent() {
+    state = state.copyWith(accentEnabled: !state.accentEnabled);
+  }
+}
+
+final metronomeProvider =
+    StateNotifierProvider<MetronomeNotifier, MetronomeState>((ref) {
+  return MetronomeNotifier();
+});

--- a/lib/features/metronome/application/metronome_provider.dart
+++ b/lib/features/metronome/application/metronome_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -10,12 +11,14 @@ class MetronomeState {
   final bool isEnabled;
   final int beatsPerMeasure;
   final bool accentEnabled;
+  final int currentBeat;
 
   const MetronomeState({
     this.bpm = 120,
     this.isEnabled = false,
     this.beatsPerMeasure = 4,
     this.accentEnabled = true,
+    this.currentBeat = 0,
   });
 
   MetronomeState copyWith({
@@ -23,12 +26,14 @@ class MetronomeState {
     bool? isEnabled,
     int? beatsPerMeasure,
     bool? accentEnabled,
+    int? currentBeat,
   }) {
     return MetronomeState(
       bpm: bpm ?? this.bpm,
       isEnabled: isEnabled ?? this.isEnabled,
       beatsPerMeasure: beatsPerMeasure ?? this.beatsPerMeasure,
       accentEnabled: accentEnabled ?? this.accentEnabled,
+      currentBeat: currentBeat ?? this.currentBeat,
     );
   }
 }
@@ -54,35 +59,96 @@ class MetronomeConstants {
 /// メトロノームの状態管理
 @riverpod
 class Metronome extends _$Metronome {
+  Timer? _timer;
+  void Function()? _onBeat;
+
   @override
   MetronomeState build() {
+    // Providerが破棄される際にタイマーをクリーンアップ
+    ref.onDispose(() {
+      _stopTimer();
+    });
     return const MetronomeState();
+  }
+
+  /// ビートコールバックを登録（Presentation層から呼ばれる）
+  void registerBeatCallback(void Function() callback) {
+    _onBeat = callback;
   }
 
   /// BPMを設定
   void setBpm(int bpm) {
-    state = state.copyWith(
-      bpm: bpm.clamp(MetronomeConstants.minBPM, MetronomeConstants.maxBPM),
-    );
+    final newBpm = bpm.clamp(MetronomeConstants.minBPM, MetronomeConstants.maxBPM);
+    state = state.copyWith(bpm: newBpm);
+
+    // 再生中の場合はタイマーを再起動
+    if (state.isEnabled) {
+      _startTimer();
+    }
   }
 
   /// メトロノームのON/OFF切り替え
   void toggle() {
-    state = state.copyWith(isEnabled: !state.isEnabled);
+    if (state.isEnabled) {
+      stop();
+    } else {
+      _start();
+    }
+  }
+
+  /// メトロノームを開始
+  void _start() {
+    state = state.copyWith(
+      isEnabled: true,
+      currentBeat: 0,
+    );
+    _startTimer();
   }
 
   /// メトロノームを停止
   void stop() {
-    state = state.copyWith(isEnabled: false);
+    _stopTimer();
+    state = state.copyWith(
+      isEnabled: false,
+      currentBeat: 0,
+    );
   }
 
   /// 拍子を設定
   void setBeatsPerMeasure(int beats) {
-    state = state.copyWith(beatsPerMeasure: beats);
+    state = state.copyWith(
+      beatsPerMeasure: beats,
+      currentBeat: 0, // 拍子変更時にビート位置をリセット
+    );
   }
 
   /// アクセントのON/OFF切り替え
   void toggleAccent() {
     state = state.copyWith(accentEnabled: !state.accentEnabled);
+  }
+
+  /// タイマーを開始
+  void _startTimer() {
+    _stopTimer(); // 既存のタイマーがあれば停止
+    final interval = Duration(milliseconds: (60000 / state.bpm).round());
+    _timer = Timer.periodic(interval, (_) {
+      _beat();
+    });
+  }
+
+  /// タイマーを停止
+  void _stopTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  /// ビート処理
+  void _beat() {
+    // コールバックを呼び出す（Presentation層で音声・アニメーション処理）
+    _onBeat?.call();
+
+    // ビート位置を更新
+    final nextBeat = (state.currentBeat + 1) % state.beatsPerMeasure;
+    state = state.copyWith(currentBeat: nextBeat);
   }
 }

--- a/lib/features/metronome/application/metronome_provider.dart
+++ b/lib/features/metronome/application/metronome_provider.dart
@@ -1,6 +1,10 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'metronome_provider.g.dart';
 
 /// メトロノームの状態
+@immutable
 class MetronomeState {
   final int bpm;
   final bool isEnabled;
@@ -29,17 +33,37 @@ class MetronomeState {
   }
 }
 
-/// メトロノームの状態管理
-class MetronomeNotifier extends StateNotifier<MetronomeState> {
-  MetronomeNotifier() : super(const MetronomeState());
+/// メトロノームの定数
+class MetronomeConstants {
+  MetronomeConstants._();
 
   /// BPM範囲
   static const int minBPM = 40;
   static const int maxBPM = 240;
 
+  /// 利用可能な拍子
+  static const List<int> availableBeats = [2, 3, 4, 6];
+
+  /// プリセットBPM
+  static const List<int> presetBPMs = [60, 80, 100, 120, 140, 160];
+
+  /// BPM変更のステップ
+  static const int bpmStep = 5;
+}
+
+/// メトロノームの状態管理
+@riverpod
+class Metronome extends _$Metronome {
+  @override
+  MetronomeState build() {
+    return const MetronomeState();
+  }
+
   /// BPMを設定
   void setBpm(int bpm) {
-    state = state.copyWith(bpm: bpm.clamp(minBPM, maxBPM));
+    state = state.copyWith(
+      bpm: bpm.clamp(MetronomeConstants.minBPM, MetronomeConstants.maxBPM),
+    );
   }
 
   /// メトロノームのON/OFF切り替え
@@ -62,8 +86,3 @@ class MetronomeNotifier extends StateNotifier<MetronomeState> {
     state = state.copyWith(accentEnabled: !state.accentEnabled);
   }
 }
-
-final metronomeProvider =
-    StateNotifierProvider<MetronomeNotifier, MetronomeState>((ref) {
-  return MetronomeNotifier();
-});

--- a/lib/features/metronome/application/metronome_provider.g.dart
+++ b/lib/features/metronome/application/metronome_provider.g.dart
@@ -6,7 +6,7 @@ part of 'metronome_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$metronomeHash() => r'aa1d170badc11f7ae21ee32d80b1e059f3aa6f89';
+String _$metronomeHash() => r'd47e3c8c464e4f1c8bedcb331b16a0b58e13ef19';
 
 /// メトロノームの状態管理
 ///

--- a/lib/features/metronome/application/metronome_provider.g.dart
+++ b/lib/features/metronome/application/metronome_provider.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'metronome_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$metronomeHash() => r'aa1d170badc11f7ae21ee32d80b1e059f3aa6f89';
+
+/// メトロノームの状態管理
+///
+/// Copied from [Metronome].
+@ProviderFor(Metronome)
+final metronomeProvider =
+    AutoDisposeNotifierProvider<Metronome, MetronomeState>.internal(
+  Metronome.new,
+  name: r'metronomeProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$metronomeHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$Metronome = AutoDisposeNotifier<MetronomeState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/practice/application/practice_video_provider.g.dart
+++ b/lib/features/practice/application/practice_video_provider.g.dart
@@ -28,7 +28,7 @@ final practiceVideoRepositoryProvider =
 // ignore: unused_element
 typedef PracticeVideoRepositoryRef
     = AutoDisposeFutureProviderRef<PracticeVideoRepository>;
-String _$presetVideosHash() => r'542b4daede090384188a1cf2e85a4cfed9e6fc81';
+String _$presetVideosHash() => r'408a3b518b95c12408befa929466638c017c1316';
 
 /// プリセット動画のプロバイダー
 ///

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'shared/theme/app_theme.dart';
 import 'presentation/screens/tuner/tuner_screen.dart';
+import 'presentation/screens/metronome/metronome_screen.dart';
 import 'presentation/screens/practice/practice_screen.dart';
 import 'presentation/screens/history/history_screen.dart';
 import 'presentation/screens/news/news_screen.dart';
@@ -49,6 +50,7 @@ class _MainScreenState extends State<MainScreen> {
 
   final List<Widget> _screens = const [
     TunerScreen(),
+    MetronomeScreen(),
     PracticeScreen(),
     HistoryScreen(),
     NewsScreen(),
@@ -59,6 +61,11 @@ class _MainScreenState extends State<MainScreen> {
       icon: Icon(Icons.music_note_outlined),
       selectedIcon: Icon(Icons.music_note),
       label: 'チューナー',
+    ),
+    NavigationDestination(
+      icon: Icon(Icons.timer_outlined),
+      selectedIcon: Icon(Icons.timer),
+      label: 'メトロノーム',
     ),
     NavigationDestination(
       icon: Icon(Icons.play_circle_outline),

--- a/lib/presentation/screens/metronome/metronome_screen.dart
+++ b/lib/presentation/screens/metronome/metronome_screen.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -26,7 +25,6 @@ class MetronomeScreen extends ConsumerStatefulWidget {
 
 class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
     with SingleTickerProviderStateMixin, WidgetsBindingObserver {
-  Timer? _timer;
   bool _isBeating = false;
   late AnimationController _animationController;
 
@@ -40,9 +38,6 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
   /// オーディオ初期化失敗フラグ
   bool _audioInitFailed = false;
 
-  /// 現在のビート位置
-  int _currentBeat = 0;
-
   @override
   void initState() {
     super.initState();
@@ -52,6 +47,11 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
       duration: _ScreenConstants.beatAnimationDuration,
     );
     _initAudioPlayers();
+
+    // ビートコールバックを登録（次のフレームで実行）
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(metronomeProvider.notifier).registerBeatCallback(_onBeat);
+    });
   }
 
   @override
@@ -95,27 +95,10 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
     }
   }
 
-  void _startMetronome(int bpm) {
-    _stopMetronome();
-    _currentBeat = 0;
-    final interval = Duration(milliseconds: (60000 / bpm).round());
-    _timer = Timer.periodic(interval, (_) {
-      _beat();
-    });
-  }
+  /// ビート発生時のコールバック（Notifierから呼ばれる）
+  void _onBeat() {
+    if (!mounted) return;
 
-  void _stopMetronome() {
-    _timer?.cancel();
-    _timer = null;
-    _currentBeat = 0;
-    if (mounted) {
-      setState(() {
-        _isBeating = false;
-      });
-    }
-  }
-
-  void _beat() {
     final state = ref.read(metronomeProvider);
 
     setState(() {
@@ -131,16 +114,13 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
       }
     });
 
-    // 音を再生
+    // 音を再生（currentBeatは次のビートに進む前の値）
     if (_isAudioReady) {
-      _playSound(state.accentEnabled && _currentBeat == 0);
+      _playSound(state.accentEnabled && state.currentBeat == 0);
     }
 
     // 触覚フィードバック
     HapticFeedback.lightImpact();
-
-    // ビート位置を更新
-    _currentBeat = (_currentBeat + 1) % state.beatsPerMeasure;
   }
 
   void _playSound(bool isAccent) {
@@ -158,7 +138,6 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    _stopMetronome();
     _animationController.dispose();
     _clickPlayer?.dispose();
     _accentPlayer?.dispose();
@@ -169,22 +148,6 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
   Widget build(BuildContext context) {
     final state = ref.watch(metronomeProvider);
     final notifier = ref.read(metronomeProvider.notifier);
-
-    // 状態変更時にメトロノームを制御
-    ref.listen<MetronomeState>(metronomeProvider, (previous, next) {
-      if (previous?.isEnabled != next.isEnabled) {
-        if (next.isEnabled) {
-          _startMetronome(next.bpm);
-        } else {
-          _stopMetronome();
-        }
-      } else if (next.isEnabled && previous?.bpm != next.bpm) {
-        _startMetronome(next.bpm);
-      } else if (next.isEnabled &&
-          previous?.beatsPerMeasure != next.beatsPerMeasure) {
-        _currentBeat = 0;
-      }
-    });
 
     return Scaffold(
       body: SafeArea(
@@ -289,7 +252,7 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: List.generate(state.beatsPerMeasure, (index) {
-                  final isActive = state.isEnabled && _currentBeat == index;
+                  final isActive = state.isEnabled && state.currentBeat == index;
                   final isAccent = index == 0 && state.accentEnabled;
                   return AnimatedContainer(
                     duration: _ScreenConstants.beatAnimationDuration,

--- a/lib/presentation/screens/metronome/metronome_screen.dart
+++ b/lib/presentation/screens/metronome/metronome_screen.dart
@@ -6,6 +6,16 @@ import 'package:audioplayers/audioplayers.dart';
 import '../../../shared/constants/app_colors.dart';
 import '../../../features/metronome/application/metronome_provider.dart';
 
+/// メトロノーム画面の定数
+class _ScreenConstants {
+  _ScreenConstants._();
+
+  static const double mainCircleSize = 200.0;
+  static const double borderWidth = 4.0;
+  static const Duration beatAnimationDuration = Duration(milliseconds: 100);
+  static const Duration glowAnimationDuration = Duration(milliseconds: 100);
+}
+
 /// メトロノーム画面
 class MetronomeScreen extends ConsumerStatefulWidget {
   const MetronomeScreen({super.key});
@@ -15,46 +25,73 @@ class MetronomeScreen extends ConsumerStatefulWidget {
 }
 
 class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, WidgetsBindingObserver {
   Timer? _timer;
   bool _isBeating = false;
   late AnimationController _animationController;
 
   /// オーディオプレーヤー
-  final AudioPlayer _clickPlayer = AudioPlayer();
-  final AudioPlayer _accentPlayer = AudioPlayer();
+  AudioPlayer? _clickPlayer;
+  AudioPlayer? _accentPlayer;
 
   /// オーディオ初期化完了フラグ
   bool _isAudioReady = false;
 
+  /// オーディオ初期化失敗フラグ
+  bool _audioInitFailed = false;
+
   /// 現在のビート位置
   int _currentBeat = 0;
-
-  /// 利用可能な拍子
-  static const List<int> _availableBeats = [2, 3, 4, 6];
-
-  /// プリセットBPM
-  static const List<int> _presetBPMs = [60, 80, 100, 120, 140, 160];
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _animationController = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 100),
+      duration: _ScreenConstants.beatAnimationDuration,
     );
     _initAudioPlayers();
   }
 
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // アプリがバックグラウンドに移行した際にメトロノームを停止
+    if (state == AppLifecycleState.paused) {
+      ref.read(metronomeProvider.notifier).stop();
+    }
+  }
+
   Future<void> _initAudioPlayers() async {
     try {
-      await _clickPlayer.setSource(AssetSource('audio/metronome_click.wav'));
-      await _accentPlayer.setSource(AssetSource('audio/metronome_accent.wav'));
-      await _clickPlayer.setReleaseMode(ReleaseMode.stop);
-      await _accentPlayer.setReleaseMode(ReleaseMode.stop);
-      _isAudioReady = true;
+      _clickPlayer = AudioPlayer();
+      _accentPlayer = AudioPlayer();
+
+      await _clickPlayer!.setSource(AssetSource('audio/metronome_click.wav'));
+      await _accentPlayer!.setSource(AssetSource('audio/metronome_accent.wav'));
+      await _clickPlayer!.setReleaseMode(ReleaseMode.stop);
+      await _accentPlayer!.setReleaseMode(ReleaseMode.stop);
+
+      if (mounted) {
+        setState(() {
+          _isAudioReady = true;
+          _audioInitFailed = false;
+        });
+      }
     } catch (e) {
       debugPrint('Failed to initialize audio players: $e');
+      // プレイヤーをクリーンアップ
+      await _clickPlayer?.dispose();
+      await _accentPlayer?.dispose();
+      _clickPlayer = null;
+      _accentPlayer = null;
+
+      if (mounted) {
+        setState(() {
+          _isAudioReady = false;
+          _audioInitFailed = true;
+        });
+      }
     }
   }
 
@@ -71,14 +108,16 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
     _timer?.cancel();
     _timer = null;
     _currentBeat = 0;
-    setState(() {
-      _isBeating = false;
-    });
+    if (mounted) {
+      setState(() {
+        _isBeating = false;
+      });
+    }
   }
 
   void _beat() {
     final state = ref.read(metronomeProvider);
-    
+
     setState(() {
       _isBeating = true;
     });
@@ -106,10 +145,10 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
 
   void _playSound(bool isAccent) {
     try {
-      if (isAccent) {
-        _accentPlayer.stop().then((_) => _accentPlayer.resume());
-      } else {
-        _clickPlayer.stop().then((_) => _clickPlayer.resume());
+      if (isAccent && _accentPlayer != null) {
+        _accentPlayer!.stop().then((_) => _accentPlayer!.resume());
+      } else if (_clickPlayer != null) {
+        _clickPlayer!.stop().then((_) => _clickPlayer!.resume());
       }
     } catch (e) {
       debugPrint('Metronome audio error: $e');
@@ -118,10 +157,11 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _stopMetronome();
     _animationController.dispose();
-    _clickPlayer.dispose();
-    _accentPlayer.dispose();
+    _clickPlayer?.dispose();
+    _accentPlayer?.dispose();
     super.dispose();
   }
 
@@ -140,7 +180,8 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
         }
       } else if (next.isEnabled && previous?.bpm != next.bpm) {
         _startMetronome(next.bpm);
-      } else if (next.isEnabled && previous?.beatsPerMeasure != next.beatsPerMeasure) {
+      } else if (next.isEnabled &&
+          previous?.beatsPerMeasure != next.beatsPerMeasure) {
         _currentBeat = 0;
       }
     });
@@ -151,15 +192,42 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
           padding: const EdgeInsets.all(20),
           child: Column(
             children: [
+              // 音声初期化失敗時の警告
+              if (_audioInitFailed)
+                Container(
+                  margin: const EdgeInsets.only(bottom: 16),
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: AppColors.error.withOpacity(0.1),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: AppColors.error),
+                  ),
+                  child: const Row(
+                    children: [
+                      Icon(Icons.warning_amber, color: AppColors.error),
+                      SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          '音声の初期化に失敗しました。\n視覚・触覚フィードバックのみで動作します。',
+                          style: TextStyle(
+                            color: AppColors.error,
+                            fontSize: 12,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
               const Spacer(),
-              
+
               // メインBPM表示
               GestureDetector(
                 onTap: () => notifier.toggle(),
                 child: AnimatedContainer(
-                  duration: const Duration(milliseconds: 100),
-                  width: 200,
-                  height: 200,
+                  duration: _ScreenConstants.glowAnimationDuration,
+                  width: _ScreenConstants.mainCircleSize,
+                  height: _ScreenConstants.mainCircleSize,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
                     color: _isBeating
@@ -169,7 +237,7 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
                       color: state.isEnabled
                           ? AppColors.primary
                           : AppColors.textGray,
-                      width: 4,
+                      width: _ScreenConstants.borderWidth,
                     ),
                     boxShadow: state.isEnabled
                         ? [
@@ -203,9 +271,9 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
                   ),
                 ),
               ),
-              
+
               const SizedBox(height: 20),
-              
+
               // タップで開始/停止の説明
               Text(
                 state.isEnabled ? 'タップで停止' : 'タップで開始',
@@ -214,9 +282,9 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
                   fontSize: 14,
                 ),
               ),
-              
+
               const SizedBox(height: 30),
-              
+
               // ビートインジケーター
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -224,26 +292,29 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
                   final isActive = state.isEnabled && _currentBeat == index;
                   final isAccent = index == 0 && state.accentEnabled;
                   return AnimatedContainer(
-                    duration: const Duration(milliseconds: 100),
+                    duration: _ScreenConstants.beatAnimationDuration,
                     margin: const EdgeInsets.symmetric(horizontal: 6),
                     width: isAccent ? 20 : 16,
                     height: isAccent ? 20 : 16,
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
                       color: isActive
-                          ? (isAccent ? AppColors.secondary : AppColors.primary)
+                          ? (isAccent
+                              ? AppColors.secondary
+                              : AppColors.primary)
                           : AppColors.backgroundLightDark,
                       border: Border.all(
-                        color: isAccent ? AppColors.secondary : AppColors.primary,
+                        color:
+                            isAccent ? AppColors.secondary : AppColors.primary,
                         width: 2,
                       ),
                     ),
                   );
                 }),
               ),
-              
+
               const Spacer(),
-              
+
               // BPM調整スライダー
               Row(
                 children: [
@@ -251,16 +322,16 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
                     icon: const Icon(Icons.remove_circle_outline, size: 32),
                     color: AppColors.textGray,
                     onPressed: () {
-                      if (state.bpm > MetronomeNotifier.minBPM) {
-                        notifier.setBpm(state.bpm - 5);
+                      if (state.bpm > MetronomeConstants.minBPM) {
+                        notifier.setBpm(state.bpm - MetronomeConstants.bpmStep);
                       }
                     },
                   ),
                   Expanded(
                     child: Slider(
                       value: state.bpm.toDouble(),
-                      min: MetronomeNotifier.minBPM.toDouble(),
-                      max: MetronomeNotifier.maxBPM.toDouble(),
+                      min: MetronomeConstants.minBPM.toDouble(),
+                      max: MetronomeConstants.maxBPM.toDouble(),
                       activeColor: AppColors.primary,
                       inactiveColor: AppColors.backgroundGray,
                       onChanged: (value) {
@@ -272,22 +343,22 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
                     icon: const Icon(Icons.add_circle_outline, size: 32),
                     color: AppColors.textGray,
                     onPressed: () {
-                      if (state.bpm < MetronomeNotifier.maxBPM) {
-                        notifier.setBpm(state.bpm + 5);
+                      if (state.bpm < MetronomeConstants.maxBPM) {
+                        notifier.setBpm(state.bpm + MetronomeConstants.bpmStep);
                       }
                     },
                   ),
                 ],
               ),
-              
+
               const SizedBox(height: 20),
-              
+
               // プリセットBPM
               Wrap(
                 spacing: 10,
                 runSpacing: 10,
                 alignment: WrapAlignment.center,
-                children: _presetBPMs.map((bpm) {
+                children: MetronomeConstants.presetBPMs.map((bpm) {
                   final isSelected = state.bpm == bpm;
                   return InkWell(
                     onTap: () => notifier.setBpm(bpm),
@@ -317,9 +388,9 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
                   );
                 }).toList(),
               ),
-              
+
               const SizedBox(height: 30),
-              
+
               // 拍子選択とアクセント
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -334,7 +405,7 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
                           fontSize: 14,
                         ),
                       ),
-                      ...(_availableBeats.map((beats) {
+                      ...(MetronomeConstants.availableBeats.map((beats) {
                         final isSelected = state.beatsPerMeasure == beats;
                         return Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 4),
@@ -367,7 +438,7 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
                       })),
                     ],
                   ),
-                  
+
                   // アクセント切り替え
                   InkWell(
                     onTap: () => notifier.toggleAccent(),
@@ -414,7 +485,7 @@ class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
                   ),
                 ],
               ),
-              
+
               const SizedBox(height: 20),
             ],
           ),

--- a/lib/presentation/screens/metronome/metronome_screen.dart
+++ b/lib/presentation/screens/metronome/metronome_screen.dart
@@ -1,0 +1,425 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:audioplayers/audioplayers.dart';
+import '../../../shared/constants/app_colors.dart';
+import '../../../features/metronome/application/metronome_provider.dart';
+
+/// メトロノーム画面
+class MetronomeScreen extends ConsumerStatefulWidget {
+  const MetronomeScreen({super.key});
+
+  @override
+  ConsumerState<MetronomeScreen> createState() => _MetronomeScreenState();
+}
+
+class _MetronomeScreenState extends ConsumerState<MetronomeScreen>
+    with SingleTickerProviderStateMixin {
+  Timer? _timer;
+  bool _isBeating = false;
+  late AnimationController _animationController;
+
+  /// オーディオプレーヤー
+  final AudioPlayer _clickPlayer = AudioPlayer();
+  final AudioPlayer _accentPlayer = AudioPlayer();
+
+  /// オーディオ初期化完了フラグ
+  bool _isAudioReady = false;
+
+  /// 現在のビート位置
+  int _currentBeat = 0;
+
+  /// 利用可能な拍子
+  static const List<int> _availableBeats = [2, 3, 4, 6];
+
+  /// プリセットBPM
+  static const List<int> _presetBPMs = [60, 80, 100, 120, 140, 160];
+
+  @override
+  void initState() {
+    super.initState();
+    _animationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 100),
+    );
+    _initAudioPlayers();
+  }
+
+  Future<void> _initAudioPlayers() async {
+    try {
+      await _clickPlayer.setSource(AssetSource('audio/metronome_click.wav'));
+      await _accentPlayer.setSource(AssetSource('audio/metronome_accent.wav'));
+      await _clickPlayer.setReleaseMode(ReleaseMode.stop);
+      await _accentPlayer.setReleaseMode(ReleaseMode.stop);
+      _isAudioReady = true;
+    } catch (e) {
+      debugPrint('Failed to initialize audio players: $e');
+    }
+  }
+
+  void _startMetronome(int bpm) {
+    _stopMetronome();
+    _currentBeat = 0;
+    final interval = Duration(milliseconds: (60000 / bpm).round());
+    _timer = Timer.periodic(interval, (_) {
+      _beat();
+    });
+  }
+
+  void _stopMetronome() {
+    _timer?.cancel();
+    _timer = null;
+    _currentBeat = 0;
+    setState(() {
+      _isBeating = false;
+    });
+  }
+
+  void _beat() {
+    final state = ref.read(metronomeProvider);
+    
+    setState(() {
+      _isBeating = true;
+    });
+
+    _animationController.forward().then((_) {
+      _animationController.reverse();
+      if (mounted) {
+        setState(() {
+          _isBeating = false;
+        });
+      }
+    });
+
+    // 音を再生
+    if (_isAudioReady) {
+      _playSound(state.accentEnabled && _currentBeat == 0);
+    }
+
+    // 触覚フィードバック
+    HapticFeedback.lightImpact();
+
+    // ビート位置を更新
+    _currentBeat = (_currentBeat + 1) % state.beatsPerMeasure;
+  }
+
+  void _playSound(bool isAccent) {
+    try {
+      if (isAccent) {
+        _accentPlayer.stop().then((_) => _accentPlayer.resume());
+      } else {
+        _clickPlayer.stop().then((_) => _clickPlayer.resume());
+      }
+    } catch (e) {
+      debugPrint('Metronome audio error: $e');
+    }
+  }
+
+  @override
+  void dispose() {
+    _stopMetronome();
+    _animationController.dispose();
+    _clickPlayer.dispose();
+    _accentPlayer.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(metronomeProvider);
+    final notifier = ref.read(metronomeProvider.notifier);
+
+    // 状態変更時にメトロノームを制御
+    ref.listen<MetronomeState>(metronomeProvider, (previous, next) {
+      if (previous?.isEnabled != next.isEnabled) {
+        if (next.isEnabled) {
+          _startMetronome(next.bpm);
+        } else {
+          _stopMetronome();
+        }
+      } else if (next.isEnabled && previous?.bpm != next.bpm) {
+        _startMetronome(next.bpm);
+      } else if (next.isEnabled && previous?.beatsPerMeasure != next.beatsPerMeasure) {
+        _currentBeat = 0;
+      }
+    });
+
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            children: [
+              const Spacer(),
+              
+              // メインBPM表示
+              GestureDetector(
+                onTap: () => notifier.toggle(),
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 100),
+                  width: 200,
+                  height: 200,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: _isBeating
+                        ? AppColors.primary
+                        : AppColors.backgroundLightDark,
+                    border: Border.all(
+                      color: state.isEnabled
+                          ? AppColors.primary
+                          : AppColors.textGray,
+                      width: 4,
+                    ),
+                    boxShadow: state.isEnabled
+                        ? [
+                            BoxShadow(
+                              color: AppColors.primary.withOpacity(0.3),
+                              blurRadius: 20,
+                              spreadRadius: 5,
+                            ),
+                          ]
+                        : null,
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        '${state.bpm}',
+                        style: const TextStyle(
+                          color: AppColors.textWhite,
+                          fontSize: 64,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const Text(
+                        'BPM',
+                        style: TextStyle(
+                          color: AppColors.textGray,
+                          fontSize: 16,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              
+              const SizedBox(height: 20),
+              
+              // タップで開始/停止の説明
+              Text(
+                state.isEnabled ? 'タップで停止' : 'タップで開始',
+                style: const TextStyle(
+                  color: AppColors.textGray,
+                  fontSize: 14,
+                ),
+              ),
+              
+              const SizedBox(height: 30),
+              
+              // ビートインジケーター
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(state.beatsPerMeasure, (index) {
+                  final isActive = state.isEnabled && _currentBeat == index;
+                  final isAccent = index == 0 && state.accentEnabled;
+                  return AnimatedContainer(
+                    duration: const Duration(milliseconds: 100),
+                    margin: const EdgeInsets.symmetric(horizontal: 6),
+                    width: isAccent ? 20 : 16,
+                    height: isAccent ? 20 : 16,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: isActive
+                          ? (isAccent ? AppColors.secondary : AppColors.primary)
+                          : AppColors.backgroundLightDark,
+                      border: Border.all(
+                        color: isAccent ? AppColors.secondary : AppColors.primary,
+                        width: 2,
+                      ),
+                    ),
+                  );
+                }),
+              ),
+              
+              const Spacer(),
+              
+              // BPM調整スライダー
+              Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.remove_circle_outline, size: 32),
+                    color: AppColors.textGray,
+                    onPressed: () {
+                      if (state.bpm > MetronomeNotifier.minBPM) {
+                        notifier.setBpm(state.bpm - 5);
+                      }
+                    },
+                  ),
+                  Expanded(
+                    child: Slider(
+                      value: state.bpm.toDouble(),
+                      min: MetronomeNotifier.minBPM.toDouble(),
+                      max: MetronomeNotifier.maxBPM.toDouble(),
+                      activeColor: AppColors.primary,
+                      inactiveColor: AppColors.backgroundGray,
+                      onChanged: (value) {
+                        notifier.setBpm(value.round());
+                      },
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.add_circle_outline, size: 32),
+                    color: AppColors.textGray,
+                    onPressed: () {
+                      if (state.bpm < MetronomeNotifier.maxBPM) {
+                        notifier.setBpm(state.bpm + 5);
+                      }
+                    },
+                  ),
+                ],
+              ),
+              
+              const SizedBox(height: 20),
+              
+              // プリセットBPM
+              Wrap(
+                spacing: 10,
+                runSpacing: 10,
+                alignment: WrapAlignment.center,
+                children: _presetBPMs.map((bpm) {
+                  final isSelected = state.bpm == bpm;
+                  return InkWell(
+                    onTap: () => notifier.setBpm(bpm),
+                    borderRadius: BorderRadius.circular(8),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 8,
+                      ),
+                      decoration: BoxDecoration(
+                        color: isSelected
+                            ? AppColors.primary
+                            : AppColors.backgroundLightDark,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        '$bpm',
+                        style: TextStyle(
+                          color: isSelected
+                              ? AppColors.textWhite
+                              : AppColors.textGray,
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  );
+                }).toList(),
+              ),
+              
+              const SizedBox(height: 30),
+              
+              // 拍子選択とアクセント
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  // 拍子選択
+                  Row(
+                    children: [
+                      const Text(
+                        '拍子: ',
+                        style: TextStyle(
+                          color: AppColors.textGray,
+                          fontSize: 14,
+                        ),
+                      ),
+                      ...(_availableBeats.map((beats) {
+                        final isSelected = state.beatsPerMeasure == beats;
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 4),
+                          child: InkWell(
+                            onTap: () => notifier.setBeatsPerMeasure(beats),
+                            borderRadius: BorderRadius.circular(6),
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 10,
+                                vertical: 6,
+                              ),
+                              decoration: BoxDecoration(
+                                color: isSelected
+                                    ? AppColors.primary
+                                    : AppColors.backgroundLightDark,
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                              child: Text(
+                                '$beats/4',
+                                style: TextStyle(
+                                  color: isSelected
+                                      ? AppColors.textWhite
+                                      : AppColors.textGray,
+                                  fontSize: 14,
+                                ),
+                              ),
+                            ),
+                          ),
+                        );
+                      })),
+                    ],
+                  ),
+                  
+                  // アクセント切り替え
+                  InkWell(
+                    onTap: () => notifier.toggleAccent(),
+                    borderRadius: BorderRadius.circular(6),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 6,
+                      ),
+                      decoration: BoxDecoration(
+                        color: state.accentEnabled
+                            ? AppColors.secondary.withOpacity(0.2)
+                            : AppColors.backgroundLightDark,
+                        borderRadius: BorderRadius.circular(6),
+                        border: Border.all(
+                          color: state.accentEnabled
+                              ? AppColors.secondary
+                              : AppColors.textGray,
+                        ),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.music_note,
+                            color: state.accentEnabled
+                                ? AppColors.secondary
+                                : AppColors.textGray,
+                            size: 18,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            'アクセント',
+                            style: TextStyle(
+                              color: state.accentEnabled
+                                  ? AppColors.secondary
+                                  : AppColors.textGray,
+                              fontSize: 14,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              
+              const SizedBox(height: 20),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/metronome/application/metronome_provider_test.dart
+++ b/test/features/metronome/application/metronome_provider_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:guitar_lovers_flutter/features/metronome/application/metronome_provider.dart';
 
 void main() {
@@ -52,6 +53,75 @@ void main() {
 
     test('BPMステップが正しい', () {
       expect(MetronomeConstants.bpmStep, 5);
+    });
+  });
+
+  group('Metronome Notifier', () {
+    test('setBpmでBPM範囲外の値をクランプする', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(metronomeProvider.notifier);
+
+      notifier.setBpm(300); // maxBPM(240)を超える
+      expect(container.read(metronomeProvider).bpm, 240);
+
+      notifier.setBpm(10); // minBPM(40)未満
+      expect(container.read(metronomeProvider).bpm, 40);
+    });
+
+    test('toggleで再生状態が切り替わる', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(metronomeProvider.notifier);
+
+      expect(container.read(metronomeProvider).isEnabled, false);
+      notifier.toggle();
+      expect(container.read(metronomeProvider).isEnabled, true);
+      notifier.toggle();
+      expect(container.read(metronomeProvider).isEnabled, false);
+    });
+
+    test('stopで再生が停止する', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(metronomeProvider.notifier);
+
+      notifier.toggle(); // 再生開始
+      expect(container.read(metronomeProvider).isEnabled, true);
+      notifier.stop();
+      expect(container.read(metronomeProvider).isEnabled, false);
+    });
+
+    test('setBeatsPerMeasureで拍子が変更される', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(metronomeProvider.notifier);
+
+      notifier.setBeatsPerMeasure(3);
+      expect(container.read(metronomeProvider).beatsPerMeasure, 3);
+    });
+
+    test('setBeatsPerMeasureでビート位置がリセットされる', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(metronomeProvider.notifier);
+
+      // 初期状態を変更してビート位置を進める（手動で状態を更新）
+      container.read(metronomeProvider.notifier);
+      // 拍子を変更
+      notifier.setBeatsPerMeasure(3);
+      // ビート位置が0にリセットされる
+      expect(container.read(metronomeProvider).currentBeat, 0);
+    });
+
+    test('toggleAccentでアクセント設定が切り替わる', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(metronomeProvider.notifier);
+
+      final initial = container.read(metronomeProvider).accentEnabled;
+      notifier.toggleAccent();
+      expect(container.read(metronomeProvider).accentEnabled, !initial);
     });
   });
 }

--- a/test/features/metronome/application/metronome_provider_test.dart
+++ b/test/features/metronome/application/metronome_provider_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:guitar_lovers_flutter/features/metronome/application/metronome_provider.dart';
+
+void main() {
+  group('MetronomeState', () {
+    test('デフォルト値が正しい', () {
+      const state = MetronomeState();
+      expect(state.bpm, 120);
+      expect(state.isEnabled, false);
+      expect(state.beatsPerMeasure, 4);
+      expect(state.accentEnabled, true);
+    });
+
+    test('copyWithが正しく動作する', () {
+      const state = MetronomeState();
+      final newState = state.copyWith(
+        bpm: 100,
+        isEnabled: true,
+        beatsPerMeasure: 3,
+        accentEnabled: false,
+      );
+
+      expect(newState.bpm, 100);
+      expect(newState.isEnabled, true);
+      expect(newState.beatsPerMeasure, 3);
+      expect(newState.accentEnabled, false);
+    });
+
+    test('copyWithで一部のみ更新できる', () {
+      const state = MetronomeState(bpm: 80);
+      final newState = state.copyWith(isEnabled: true);
+
+      expect(newState.bpm, 80); // 変更されていない
+      expect(newState.isEnabled, true);
+      expect(newState.beatsPerMeasure, 4); // デフォルト値
+    });
+  });
+
+  group('MetronomeConstants', () {
+    test('BPM範囲が正しい', () {
+      expect(MetronomeConstants.minBPM, 40);
+      expect(MetronomeConstants.maxBPM, 240);
+    });
+
+    test('利用可能な拍子が正しい', () {
+      expect(MetronomeConstants.availableBeats, [2, 3, 4, 6]);
+    });
+
+    test('プリセットBPMが正しい', () {
+      expect(MetronomeConstants.presetBPMs, [60, 80, 100, 120, 140, 160]);
+    });
+
+    test('BPMステップが正しい', () {
+      expect(MetronomeConstants.bpmStep, 5);
+    });
+  });
+}


### PR DESCRIPTION
## 概要
メトロノームを練習画面から独立させ、専用の画面として追加しました。

## 変更内容

### 新機能
- 🎵 **独立したメトロノーム画面**: ナビゲーションバーに専用タブを追加（チューナーの隣）
- ⏱️ **大きなBPM表示**: タップで開始/停止
- 🎚️ **BPMスライダー**: スムーズな調整
- 📊 **プリセットBPM**: 60, 80, 100, 120, 140, 160
- 🎼 **拍子選択**: 2/4, 3/4, 4/4, 6/4
- 🔔 **アクセント音**: 1拍目を強調（ON/OFF可能）
- 💡 **ビートインジケーター**: 現在のビート位置を視覚表示

### 技術的な変更
- `lib/features/metronome/application/metronome_provider.dart`: 専用の状態管理
- `lib/presentation/screens/metronome/metronome_screen.dart`: メトロノーム画面
- `lib/main.dart`: ナビゲーションバーに追加

### 修正
- メトロノームが止められない問題を解消（専用Providerで状態管理を分離）

## スクリーンショット
（実機またはシミュレーターでの動作確認推奨）

## テスト方法
1. アプリを起動
2. ナビゲーションバーの「メトロノーム」タブをタップ
3. 中央の大きな円をタップして開始/停止を確認
4. BPMスライダーやプリセットで速度を変更
5. 拍子やアクセントを変更して動作確認
