### PR TITLE
feature: チューナーのプリセット対応とテスト拡充

### DIFF
--- a/lib/features/tuner/domain/services/pitch_calculation_service.dart
+++ b/lib/features/tuner/domain/services/pitch_calculation_service.dart
@@ -24,20 +24,21 @@ class PitchCalculationService {
       return {'note': '', 'cents': 0.0, 'octave': 0};
     }
 
-    // A4 = 440Hzを基準
+    // A4 = 440Hzを基準（MIDIノート番号69）
     const double a4 = 440.0;
-    const int a4Index = 57; // A4はMIDIノート番号57
+    const int a4MidiNote = 69;
 
     // 周波数からMIDIノート番号を計算
-    final double midiNote = 12 * log(frequency / a4) / log(2) + a4Index;
+    final double midiNote = 12 * log(frequency / a4) / log(2) + a4MidiNote;
     final int nearestMidiNote = midiNote.round();
 
     // セント(1半音の100分の1)を計算
     final double cents = (midiNote - nearestMidiNote) * 100;
 
     // 音名とオクターブを取得
+    // MIDIノート0はC-1、12はC0、24はC1...
     final int noteIndex = nearestMidiNote % 12;
-    final int octave = (nearestMidiNote / 12).floor() - 1;
+    final int octave = (nearestMidiNote ~/ 12) - 1;
     final String note = noteNames[noteIndex];
 
     return {
@@ -69,13 +70,58 @@ class PitchCalculationService {
 
     if (noteIndex == -1) return 0.0;
 
-    // MIDIノート番号を計算
-    const int a4MidiNote = 57;
+    // MIDIノート番号を計算（C-1=0, C0=12, C1=24, ... A4=69）
+    const int a4MidiNote = 69;
     const double a4Frequency = 440.0;
     final int midiNote = (octave + 1) * 12 + noteIndex;
 
     // 周波数を計算
     final double frequency = a4Frequency * pow(2, (midiNote - a4MidiNote) / 12);
     return frequency;
+  }
+
+  /// 周波数から最も近い弦を判定（チューニング対応）
+  /// 
+  /// [frequency] 検出された周波数
+  /// [tuningFrequencies] 各弦の基準周波数 (Map<弦番号, 周波数>)
+  /// [threshold] 判定閾値（デフォルト30Hz、約±4半音）
+  /// 
+  /// 戻り値: 弦番号（1-6）、判定不能な場合は0
+  static int detectGuitarString(
+    double frequency,
+    Map<int, double> tuningFrequencies, {
+    double threshold = 30.0,
+  }) {
+    if (frequency <= 0) return 0;
+
+    int closestString = 0;
+    double minDiff = double.infinity;
+
+    tuningFrequencies.forEach((stringNum, targetFreq) {
+      final diff = (frequency - targetFreq).abs();
+      if (diff < minDiff && diff < threshold) {
+        minDiff = diff;
+        closestString = stringNum;
+      }
+    });
+
+    return closestString;
+  }
+
+  /// 周波数と基準周波数からセント値を計算
+  static double calculateCentsFromTarget(double frequency, double targetFrequency) {
+    if (frequency <= 0 || targetFrequency <= 0) return 0.0;
+    return 1200 * log(frequency / targetFrequency) / ln2;
+  }
+
+  /// 弦ごとの基準周波数に対するセント値を計算
+  static double calculateCentsForString(
+    double frequency,
+    int stringNum,
+    Map<int, double> tuningFrequencies,
+  ) {
+    final targetFreq = tuningFrequencies[stringNum];
+    if (targetFreq == null || targetFreq <= 0) return 0.0;
+    return calculateCentsFromTarget(frequency, targetFreq);
   }
 }

--- a/lib/features/tuner/domain/tuning.dart
+++ b/lib/features/tuner/domain/tuning.dart
@@ -2,26 +2,109 @@
 class Tuning {
   final String name;
   final List<String> notes;
+  final Map<int, double> frequencies;
 
   const Tuning({
     required this.name,
     required this.notes,
+    required this.frequencies,
   });
 
+  /// プリセット一覧
   static const List<Tuning> presets = [
     Tuning(
       name: 'Standard',
       notes: ['E2', 'A2', 'D3', 'G3', 'B3', 'E4'],
+      frequencies: {
+        6: 82.41,   // E2
+        5: 110.0,   // A2
+        4: 146.83,  // D3
+        3: 196.0,   // G3
+        2: 246.94,  // B3
+        1: 329.63,  // E4
+      },
     ),
     Tuning(
       name: 'Half Step Down',
       notes: ['Eb2', 'Ab2', 'Db3', 'Gb3', 'Bb3', 'Eb4'],
+      frequencies: {
+        6: 77.78,   // Eb2
+        5: 103.83,  // Ab2
+        4: 138.59,  // Db3
+        3: 185.0,   // Gb3
+        2: 233.08,  // Bb3
+        1: 311.13,  // Eb4
+      },
     ),
     Tuning(
       name: 'Drop D',
       notes: ['D2', 'A2', 'D3', 'G3', 'B3', 'E4'],
+      frequencies: {
+        6: 73.42,   // D2
+        5: 110.0,   // A2
+        4: 146.83,  // D3
+        3: 196.0,   // G3
+        2: 246.94,  // B3
+        1: 329.63,  // E4
+      },
+    ),
+    Tuning(
+      name: 'Drop C',
+      notes: ['C2', 'G2', 'C3', 'F3', 'A3', 'D4'],
+      frequencies: {
+        6: 65.41,   // C2
+        5: 98.0,    // G2
+        4: 130.81,  // C3
+        3: 174.61,  // F3
+        2: 220.0,   // A3
+        1: 293.66,  // D4
+      },
+    ),
+    Tuning(
+      name: 'Open G',
+      notes: ['D2', 'G2', 'D3', 'G3', 'B3', 'D4'],
+      frequencies: {
+        6: 73.42,   // D2
+        5: 98.0,    // G2
+        4: 146.83,  // D3
+        3: 196.0,   // G3
+        2: 246.94,  // B3
+        1: 293.66,  // D4
+      },
+    ),
+    Tuning(
+      name: 'DADGAD',
+      notes: ['D2', 'A2', 'D3', 'G3', 'A3', 'D4'],
+      frequencies: {
+        6: 73.42,   // D2
+        5: 110.0,   // A2
+        4: 146.83,  // D3
+        3: 196.0,   // G3
+        2: 220.0,   // A3
+        1: 293.66,  // D4
+      },
     ),
   ];
+
+  /// 名前からチューニングを取得
+  static Tuning getByName(String name) {
+    return presets.firstWhere(
+      (t) => t.name == name,
+      orElse: () => presets.first,
+    );
+  }
+
+  /// 弦番号から音名を取得（1-6）
+  String getNoteForString(int stringNum) {
+    if (stringNum < 1 || stringNum > 6) return '';
+    // notes配列は[6弦, 5弦, 4弦, 3弦, 2弦, 1弦]の順
+    return notes[6 - stringNum];
+  }
+
+  /// 弦番号から周波数を取得
+  double getFrequencyForString(int stringNum) {
+    return frequencies[stringNum] ?? 0.0;
+  }
 }
 
 /// チューナーの状態

--- a/lib/presentation/screens/tuner/tuner_screen.dart
+++ b/lib/presentation/screens/tuner/tuner_screen.dart
@@ -28,6 +28,9 @@ class _TunerScreenState extends ConsumerState<TunerScreen> {
   /// セント差がこの値を超えたらスムージングをリセット (新しい音符と判断)
   static const double _centsResetThreshold = 50.0;
 
+  /// チューニング完了とみなすセント閾値（±15セント以内）
+  static const double _tuningThresholdCents = 15.0;
+
   int _lastDetectedString = 0;
   int _sameStringCount = 0;
 
@@ -330,7 +333,8 @@ class _TunerScreenState extends ConsumerState<TunerScreen> {
                         if (selected && _selectedTuning != tuning.name) {
                           setState(() {
                             _selectedTuning = tuning.name;
-                            // チューニング変更時に状態をリセット
+                            // チューニング変更時は以前の検出状態が無効になるためリセット
+                            // （異なるチューニングでは弦の基準周波数が変わるため）
                             _resetAllTuning();
                             _lastStableString = 0;
                             _lastDetectedString = 0;
@@ -481,8 +485,8 @@ class _TunerScreenState extends ConsumerState<TunerScreen> {
         cents = _smoothCents(pitchData.cents);
       }
 
-      // チューニング状態の更新（±15セント以内でチューニング完了とみなす）
-      final isInTune = cents.abs() < 15;
+      // チューニング状態の更新
+      final isInTune = cents.abs() < _tuningThresholdCents;
       _updateTuningStatus(currentString, isInTune, pitchData.probability);
     } else {
       _emptyCount++;

--- a/lib/presentation/screens/tuner/tuner_screen.dart
+++ b/lib/presentation/screens/tuner/tuner_screen.dart
@@ -4,6 +4,7 @@ import '../../../shared/constants/app_colors.dart';
 import '../../../features/tuner/domain/tuning.dart';
 import '../../../features/tuner/application/pitch_detector_provider.dart';
 import '../../../features/tuner/domain/pitch_data.dart';
+import '../../../features/tuner/domain/services/pitch_calculation_service.dart';
 
 /// チューナー画面
 class TunerScreen extends ConsumerStatefulWidget {
@@ -102,19 +103,32 @@ class _TunerScreenState extends ConsumerState<TunerScreen> {
     }
   }
 
+  /// 現在選択されているチューニングを取得
+  Tuning get _currentTuning => Tuning.getByName(_selectedTuning);
+
   String _getStringName(int stringNum) {
     if (stringNum == 0) return '';
+    final note = _currentTuning.getNoteForString(stringNum);
+    // 音名からオクターブを除去（例: "E2" -> "E"）
+    final noteName = note.replaceAll(RegExp(r'[0-9]'), '');
+    return '$stringNum弦 ($noteName)';
+  }
 
-    const stringNames = {
-      6: 'E',
-      5: 'A',
-      4: 'D',
-      3: 'G',
-      2: 'B',
-      1: 'E',
-    };
+  /// 周波数から弦を判定（選択されたチューニングを使用）
+  int _detectString(double frequency) {
+    return PitchCalculationService.detectGuitarString(
+      frequency,
+      _currentTuning.frequencies,
+    );
+  }
 
-    return '$stringNum弦 (${stringNames[stringNum]})';
+  /// 弦に対するセント値を計算（選択されたチューニングを使用）
+  double _calculateCentsForString(double frequency, int stringNum) {
+    return PitchCalculationService.calculateCentsForString(
+      frequency,
+      stringNum,
+      _currentTuning.frequencies,
+    );
   }
 
   double _smoothCents(double currentCents) {
@@ -171,17 +185,10 @@ class _TunerScreenState extends ConsumerState<TunerScreen> {
 
   /// 全弦のチューニング状態を表示
   Widget _buildAllStringsDisplay(PitchData? pitchData) {
-    // 標準チューニングの音名
-    const stringNotes = {
-      6: 'E',
-      5: 'A',
-      4: 'D',
-      3: 'G',
-      2: 'B',
-      1: 'E',
-    };
-
-    final currentString = pitchData?.guitarString ?? 0;
+    // 現在のチューニングから弦を判定
+    final currentString = pitchData != null && pitchData.isPitched
+        ? _detectString(pitchData.frequency)
+        : 0;
 
     return Container(
       padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
@@ -194,7 +201,9 @@ class _TunerScreenState extends ConsumerState<TunerScreen> {
         children: [6, 5, 4, 3, 2, 1].map((stringNum) {
           final isCurrent = currentString == stringNum;
           final isTuned = _stringTuned[stringNum] ?? false;
-          final note = stringNotes[stringNum] ?? '';
+          // 選択されたチューニングから音名を取得
+          final fullNote = _currentTuning.getNoteForString(stringNum);
+          final note = fullNote.replaceAll(RegExp(r'[0-9]'), '');
 
           return _buildStringIndicator(
             stringNum: stringNum,
@@ -321,6 +330,11 @@ class _TunerScreenState extends ConsumerState<TunerScreen> {
                         if (selected && _selectedTuning != tuning.name) {
                           setState(() {
                             _selectedTuning = tuning.name;
+                            // チューニング変更時に状態をリセット
+                            _resetAllTuning();
+                            _lastStableString = 0;
+                            _lastDetectedString = 0;
+                            _sameStringCount = 0;
                           });
                         }
                       },
@@ -439,17 +453,20 @@ class _TunerScreenState extends ConsumerState<TunerScreen> {
       currentNote = pitchData.noteName;
       isActuallyDetecting = true;
 
+      // 選択されたチューニングに基づいて弦を判定
+      final detectedString = _detectString(pitchData.frequency);
+
       // 弦番号の判定：連続して3回同じ弦が検出された場合のみ更新
-      if (pitchData.guitarString > 0) {
-        if (_lastDetectedString == pitchData.guitarString) {
+      if (detectedString > 0) {
+        if (_lastDetectedString == detectedString) {
           _sameStringCount++;
           if (_sameStringCount >= 3) {
             // 3回連続で同じ弦が検出されたので確定
-            _lastStableString = pitchData.guitarString;
+            _lastStableString = detectedString;
           }
         } else {
           // 弦が変わったのでカウントリセット
-          _lastDetectedString = pitchData.guitarString;
+          _lastDetectedString = detectedString;
           _sameStringCount = 1;
         }
       }
@@ -457,12 +474,16 @@ class _TunerScreenState extends ConsumerState<TunerScreen> {
       currentString = _lastStableString;
       _lastStableNote = pitchData.noteName;
 
-      // セント値のスムージングで外れた値を抑制
-      cents = _smoothCents(pitchData.cents);
+      // 選択されたチューニングに基づいてセント値を計算
+      if (currentString > 0) {
+        cents = _smoothCents(_calculateCentsForString(pitchData.frequency, currentString));
+      } else {
+        cents = _smoothCents(pitchData.cents);
+      }
 
-      // チューニング状態の更新
-      _updateTuningStatus(
-          currentString, pitchData.isInTune, pitchData.probability);
+      // チューニング状態の更新（±15セント以内でチューニング完了とみなす）
+      final isInTune = cents.abs() < 15;
+      _updateTuningStatus(currentString, isInTune, pitchData.probability);
     } else {
       _emptyCount++;
       if (_emptyCount >= _emptyThreshold) {

--- a/test/features/history/domain/practice_session_test.dart
+++ b/test/features/history/domain/practice_session_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:guitar_lovers_flutter/features/history/domain/practice_session.dart';
+
+void main() {
+  group('PracticeSession', () {
+    test('createで正しく生成される', () {
+      final session = PracticeSession.create(
+        durationMinutes: 30,
+        notes: 'テスト練習',
+      );
+
+      expect(session.id, isNotEmpty);
+      expect(session.durationMinutes, 30);
+      expect(session.notes, 'テスト練習');
+      expect(session.dateTime, isNotNull);
+    });
+
+    test('createでnotesがnullでも生成される', () {
+      final session = PracticeSession.create(
+        durationMinutes: 15,
+      );
+
+      expect(session.durationMinutes, 15);
+      expect(session.notes, isNull);
+    });
+
+    test('fromJsonとtoJsonが正しく動作する', () {
+      final session = PracticeSession.create(
+        durationMinutes: 45,
+        notes: 'スケール練習',
+      );
+
+      final json = session.toJson();
+      final restored = PracticeSession.fromJson(json);
+
+      expect(restored.id, session.id);
+      expect(restored.durationMinutes, session.durationMinutes);
+      expect(restored.notes, session.notes);
+      expect(restored.dateTime.toIso8601String(), session.dateTime.toIso8601String());
+    });
+
+    test('copyWithが正しく動作する', () {
+      final session = PracticeSession.create(
+        durationMinutes: 30,
+        notes: '元のメモ',
+      );
+
+      final updated = session.copyWith(
+        durationMinutes: 60,
+        notes: '更新されたメモ',
+      );
+
+      expect(updated.id, session.id); // IDは変わらない
+      expect(updated.durationMinutes, 60);
+      expect(updated.notes, '更新されたメモ');
+    });
+
+    test('copyWithで一部のみ更新できる', () {
+      final session = PracticeSession.create(
+        durationMinutes: 30,
+        notes: 'メモ',
+      );
+
+      final updated = session.copyWith(durationMinutes: 45);
+
+      expect(updated.durationMinutes, 45);
+      expect(updated.notes, 'メモ'); // 変更されていない
+    });
+  });
+}

--- a/test/features/tuner/domain/services/pitch_calculation_service_test.dart
+++ b/test/features/tuner/domain/services/pitch_calculation_service_test.dart
@@ -43,7 +43,7 @@ void main() {
 
       test('E2 が約82.41Hzを返す', () {
         final freq = PitchCalculationService.noteToFrequency('E2');
-        expect(freq, closeTo(82.41, 1.0));
+        expect(freq, closeTo(82.41, 0.5));
       });
 
       test('空文字は0を返す', () {

--- a/test/features/tuner/domain/services/pitch_calculation_service_test.dart
+++ b/test/features/tuner/domain/services/pitch_calculation_service_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:guitar_lovers_flutter/features/tuner/domain/services/pitch_calculation_service.dart';
+import 'package:guitar_lovers_flutter/features/tuner/domain/tuning.dart';
+
+void main() {
+  group('PitchCalculationService', () {
+    group('frequencyToNote', () {
+      test('A4 (440Hz) が正しく変換される', () {
+        final result = PitchCalculationService.frequencyToNote(440.0);
+        expect(result['note'], 'A4');
+        expect((result['cents'] as double).abs(), lessThan(1));
+      });
+
+      test('C4 (約261.63Hz) が正しく変換される', () {
+        final result = PitchCalculationService.frequencyToNote(261.63);
+        expect(result['note'], 'C4');
+        expect((result['cents'] as double).abs(), lessThan(5));
+      });
+
+      test('E2 (約82.41Hz) が正しく変換される', () {
+        final result = PitchCalculationService.frequencyToNote(82.41);
+        expect(result['note'], 'E2');
+        expect((result['cents'] as double).abs(), lessThan(5));
+      });
+
+      test('0Hz以下は空の結果を返す', () {
+        final result = PitchCalculationService.frequencyToNote(0);
+        expect(result['note'], '');
+        expect(result['cents'], 0.0);
+      });
+
+      test('負の周波数は空の結果を返す', () {
+        final result = PitchCalculationService.frequencyToNote(-100);
+        expect(result['note'], '');
+      });
+    });
+
+    group('noteToFrequency', () {
+      test('A4 が440Hzを返す', () {
+        final freq = PitchCalculationService.noteToFrequency('A4');
+        expect(freq, closeTo(440.0, 0.1));
+      });
+
+      test('E2 が約82.41Hzを返す', () {
+        final freq = PitchCalculationService.noteToFrequency('E2');
+        expect(freq, closeTo(82.41, 1.0));
+      });
+
+      test('空文字は0を返す', () {
+        final freq = PitchCalculationService.noteToFrequency('');
+        expect(freq, 0.0);
+      });
+    });
+
+    group('detectGuitarString', () {
+      final standardFrequencies = Tuning.getByName('Standard').frequencies;
+      final dropDFrequencies = Tuning.getByName('Drop D').frequencies;
+
+      test('Standardチューニングで6弦E2 (82.41Hz) を正しく検出', () {
+        final stringNum = PitchCalculationService.detectGuitarString(
+          82.41,
+          standardFrequencies,
+        );
+        expect(stringNum, 6);
+      });
+
+      test('Standardチューニングで1弦E4 (329.63Hz) を正しく検出', () {
+        final stringNum = PitchCalculationService.detectGuitarString(
+          329.63,
+          standardFrequencies,
+        );
+        expect(stringNum, 1);
+      });
+
+      test('Standardチューニングで5弦A2 (110Hz) を正しく検出', () {
+        final stringNum = PitchCalculationService.detectGuitarString(
+          110.0,
+          standardFrequencies,
+        );
+        expect(stringNum, 5);
+      });
+
+      test('Drop Dチューニングで6弦D2 (73.42Hz) を正しく検出', () {
+        final stringNum = PitchCalculationService.detectGuitarString(
+          73.42,
+          dropDFrequencies,
+        );
+        expect(stringNum, 6);
+      });
+
+      test('閾値を超える周波数は0を返す', () {
+        final stringNum = PitchCalculationService.detectGuitarString(
+          500.0, // どの弦からも離れている
+          standardFrequencies,
+        );
+        expect(stringNum, 0);
+      });
+
+      test('0Hz以下は0を返す', () {
+        final stringNum = PitchCalculationService.detectGuitarString(
+          0,
+          standardFrequencies,
+        );
+        expect(stringNum, 0);
+      });
+
+      test('カスタム閾値が動作する', () {
+        // 閾値を小さくすると検出が厳しくなる
+        final stringNum = PitchCalculationService.detectGuitarString(
+          85.0, // E2(82.41Hz)から約3Hz離れている
+          standardFrequencies,
+          threshold: 2.0, // 2Hz以内のみ検出
+        );
+        expect(stringNum, 0); // 検出されない
+      });
+    });
+
+    group('calculateCentsFromTarget', () {
+      test('同じ周波数は0セントを返す', () {
+        final cents = PitchCalculationService.calculateCentsFromTarget(440.0, 440.0);
+        expect(cents, closeTo(0.0, 0.1));
+      });
+
+      test('1オクターブ上は1200セントを返す', () {
+        final cents = PitchCalculationService.calculateCentsFromTarget(880.0, 440.0);
+        expect(cents, closeTo(1200.0, 0.1));
+      });
+
+      test('1オクターブ下は-1200セントを返す', () {
+        final cents = PitchCalculationService.calculateCentsFromTarget(220.0, 440.0);
+        expect(cents, closeTo(-1200.0, 0.1));
+      });
+
+      test('少し高い周波数は正のセントを返す', () {
+        // 445Hzは440Hzより約19.6セント高い
+        final cents = PitchCalculationService.calculateCentsFromTarget(445.0, 440.0);
+        expect(cents, greaterThan(0));
+        expect(cents, closeTo(19.6, 1.0));
+      });
+
+      test('少し低い周波数は負のセントを返す', () {
+        // 435Hzは440Hzより約-19.8セント低い
+        final cents = PitchCalculationService.calculateCentsFromTarget(435.0, 440.0);
+        expect(cents, lessThan(0));
+        expect(cents, closeTo(-19.8, 1.0));
+      });
+
+      test('0Hzの周波数は0セントを返す', () {
+        final cents = PitchCalculationService.calculateCentsFromTarget(0, 440.0);
+        expect(cents, 0.0);
+      });
+
+      test('0Hzの基準周波数は0セントを返す', () {
+        final cents = PitchCalculationService.calculateCentsFromTarget(440.0, 0);
+        expect(cents, 0.0);
+      });
+    });
+
+    group('calculateCentsForString', () {
+      final standardFrequencies = Tuning.getByName('Standard').frequencies;
+
+      test('6弦の基準周波数と同じ場合は0セントを返す', () {
+        final cents = PitchCalculationService.calculateCentsForString(
+          82.41, // E2
+          6,
+          standardFrequencies,
+        );
+        expect(cents.abs(), lessThan(1.0));
+      });
+
+      test('6弦より少し高い場合は正のセントを返す', () {
+        final cents = PitchCalculationService.calculateCentsForString(
+          85.0, // E2より少し高い
+          6,
+          standardFrequencies,
+        );
+        expect(cents, greaterThan(0));
+      });
+
+      test('存在しない弦番号は0セントを返す', () {
+        final cents = PitchCalculationService.calculateCentsForString(
+          440.0,
+          7, // 存在しない弦
+          standardFrequencies,
+        );
+        expect(cents, 0.0);
+      });
+    });
+  });
+}

--- a/test/features/tuner/domain/tuning_test.dart
+++ b/test/features/tuner/domain/tuning_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:guitar_lovers_flutter/features/tuner/domain/tuning.dart';
+
+void main() {
+  group('Tuning', () {
+    test('プリセットが正しく定義されている', () {
+      expect(Tuning.presets.length, greaterThanOrEqualTo(3));
+      expect(Tuning.presets.map((t) => t.name), contains('Standard'));
+      expect(Tuning.presets.map((t) => t.name), contains('Half Step Down'));
+      expect(Tuning.presets.map((t) => t.name), contains('Drop D'));
+    });
+
+    test('Standardチューニングの周波数が正しい', () {
+      final standard = Tuning.getByName('Standard');
+      expect(standard.name, 'Standard');
+      expect(standard.frequencies[6], closeTo(82.41, 0.1)); // E2
+      expect(standard.frequencies[5], closeTo(110.0, 0.1)); // A2
+      expect(standard.frequencies[4], closeTo(146.83, 0.1)); // D3
+      expect(standard.frequencies[3], closeTo(196.0, 0.1)); // G3
+      expect(standard.frequencies[2], closeTo(246.94, 0.1)); // B3
+      expect(standard.frequencies[1], closeTo(329.63, 0.1)); // E4
+    });
+
+    test('Drop Dチューニングの6弦がD2になっている', () {
+      final dropD = Tuning.getByName('Drop D');
+      expect(dropD.name, 'Drop D');
+      expect(dropD.frequencies[6], closeTo(73.42, 0.1)); // D2
+      expect(dropD.frequencies[5], closeTo(110.0, 0.1)); // A2（Standard同様）
+    });
+
+    test('Half Step Downチューニングの周波数が正しい', () {
+      final halfStepDown = Tuning.getByName('Half Step Down');
+      expect(halfStepDown.name, 'Half Step Down');
+      expect(halfStepDown.frequencies[6], closeTo(77.78, 0.1)); // Eb2
+      expect(halfStepDown.frequencies[1], closeTo(311.13, 0.1)); // Eb4
+    });
+
+    test('getByNameで存在しない名前を指定するとStandardを返す', () {
+      final tuning = Tuning.getByName('存在しないチューニング');
+      expect(tuning.name, 'Standard');
+    });
+
+    test('getNoteForStringが正しい音名を返す', () {
+      final standard = Tuning.getByName('Standard');
+      expect(standard.getNoteForString(6), 'E2');
+      expect(standard.getNoteForString(5), 'A2');
+      expect(standard.getNoteForString(4), 'D3');
+      expect(standard.getNoteForString(3), 'G3');
+      expect(standard.getNoteForString(2), 'B3');
+      expect(standard.getNoteForString(1), 'E4');
+    });
+
+    test('getNoteForStringで範囲外の弦番号を指定すると空文字を返す', () {
+      final standard = Tuning.getByName('Standard');
+      expect(standard.getNoteForString(0), '');
+      expect(standard.getNoteForString(7), '');
+      expect(standard.getNoteForString(-1), '');
+    });
+
+    test('getFrequencyForStringが正しい周波数を返す', () {
+      final standard = Tuning.getByName('Standard');
+      expect(standard.getFrequencyForString(6), closeTo(82.41, 0.1));
+      expect(standard.getFrequencyForString(1), closeTo(329.63, 0.1));
+    });
+
+    test('getFrequencyForStringで存在しない弦番号を指定すると0を返す', () {
+      final standard = Tuning.getByName('Standard');
+      expect(standard.getFrequencyForString(0), 0.0);
+      expect(standard.getFrequencyForString(7), 0.0);
+    });
+  });
+
+  group('TunerState', () {
+    test('デフォルト値が正しい', () {
+      final state = TunerState();
+      expect(state.isListening, false);
+      expect(state.currentNote, '');
+      expect(state.cents, 0.0);
+      expect(state.selectedTuning, 'Standard');
+    });
+
+    test('copyWithが正しく動作する', () {
+      final state = TunerState();
+      final newState = state.copyWith(
+        isListening: true,
+        currentNote: 'E',
+        cents: 5.0,
+        selectedTuning: 'Drop D',
+      );
+
+      expect(newState.isListening, true);
+      expect(newState.currentNote, 'E');
+      expect(newState.cents, 5.0);
+      expect(newState.selectedTuning, 'Drop D');
+    });
+
+    test('copyWithで一部のみ更新できる', () {
+      final state = TunerState(selectedTuning: 'Drop D');
+      final newState = state.copyWith(isListening: true);
+
+      expect(newState.isListening, true);
+      expect(newState.selectedTuning, 'Drop D'); // 変更されていない
+    });
+  });
+}


### PR DESCRIPTION
## 概要
チューナーのプリセット（Half Step Down, Drop D等）が実際に動作するように修正し、テストを大幅に拡充しました。

## 変更内容

### 🎸 チューナーのプリセット対応
今まではUIでプリセットを選択しても、弦判定はStandard固定でした。この修正で実際に選択したチューニングに応じて弦を判定します。

**修正内容:**
- `Tuning`クラスに各弦の周波数を追加
- `PitchCalculationService`に弦判定メソッドを追加
- `TunerScreen`を修正して選択されたチューニングを使用

**対応プリセット:**
- Standard (E A D G B E)
- Half Step Down (Eb Ab Db Gb Bb Eb)
- Drop D (D A D G B E)
- Drop C (C G C F A D) ← 新規追加
- Open G (D G D G B D) ← 新規追加
- DADGAD (D A D G A D) ← 新規追加

### 🧪 テスト拡充（49テスト）
- `Tuning`クラスのテスト
- `PitchCalculationService`のテスト
- `PracticeSession`のテスト

### 🐛 バグ修正
- MIDIノート計算のオクターブがずれていた問題を修正
  - 例: 440Hzが「A3」ではなく「A4」と正しく表示されるように

## テスト方法
1. `flutter test` でテスト実行
2. アプリを起動してチューナーを開く
3. プリセットを「Drop D」等に変更
4. 6弦をDに合わせて、正しく判定されることを確認
